### PR TITLE
Update API project configs

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>

--- a/auth/auth.csproj
+++ b/auth/auth.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>

--- a/wfe/index.js
+++ b/wfe/index.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(express.static('www'));
 
 // startup on the appropriate port
-var port = process.env.PORT || 80;
+var port = process.env.PORT || 8080;
 var hostUrl = process.env.HOST_URL;
 if (hostUrl) {
     var s = hostUrl.split(':');


### PR DESCRIPTION
The API project was producing a null reference error when parsing the Azure App Configuration keys. 
By changing the way that the api/config.js parse the keys from using JsonSerializer+Keys class to resemble auth/config.js using JObject, the soultion was able to run without error. 

Visual Studio Code does not allow a target reference of netcoreapp3.1 or above. By changing the target reference to netcoreapp3.0, the .Net Core solutions were able to build successfully. 